### PR TITLE
Bugfix/particle list

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,5 +97,3 @@ This project makes used of LGPL licensed software [QT for Python](https://doc.qt
 ## Special Thanks
  * Skin Spotlights
  * League of Editing
-
-Hello World!

--- a/README.md
+++ b/README.md
@@ -97,3 +97,5 @@ This project makes used of LGPL licensed software [QT for Python](https://doc.qt
 ## Special Thanks
  * Skin Spotlights
  * League of Editing
+
+Hello World!

--- a/leaguedirector/app.py
+++ b/leaguedirector/app.py
@@ -330,6 +330,7 @@ class ParticlesWindow(VBoxWidget):
     def __init__(self, api):
         VBoxWidget.__init__(self)
         self.api = api
+        self.api.connected.connect(self.connect)
         self.api.particles.updated.connect(self.update)
         self.items = {}
         self.search = QLineEdit()
@@ -356,6 +357,9 @@ class ParticlesWindow(VBoxWidget):
         if enabled != self.api.particles.getParticle(particle):
             self.api.particles.setParticle(particle, enabled)
 
+    def connect(self):
+        self.search.clear()
+
     def update(self):
         for particle, enabled in self.api.particles.items():
             if particle not in self.items:
@@ -367,7 +371,9 @@ class ParticlesWindow(VBoxWidget):
             self.items[particle].setCheckState(Qt.Checked if enabled else Qt.Unchecked)
         for particle in list(self.items):
             if not self.api.particles.hasParticle(particle):
-                self.list.removeItemWidget(self.items.pop(particle))
+                item = self.items.pop(particle)
+                self.list.takeItem(self.list.row(item))
+                
 
 
 class RecordingWindow(VBoxWidget):


### PR DESCRIPTION
Particle list was not being updated correctly when working between replays. It was using removeItemWidget to try remove particle toggles that are not applicable for the current replay. This function does not remove the QListWidgetItem, but the widget associated with it so it explains why it did not look like it was correctly updating. This has been replaced with takeItem function call which does remove the QListWidgetItem.

In addition, for improved UX I clear the search box when the user connects to a new replay.