### PR TITLE
Bugfix for Boolean input widgets being non functional and not resetting.

### DIFF
--- a/leaguedirector/widgets.py
+++ b/leaguedirector/widgets.py
@@ -201,7 +201,7 @@ class BooleanInput(QWidget):
         self.setLayout(self.layout)
 
     def handleValueChanged(self, state):
-        self.valueChanged.emit(bool(state == Qt.Checked))
+        self.valueChanged.emit(bool(state == Qt.Checked.value))
 
     def update(self, value):
         self.blockSignals(True)


### PR DESCRIPTION
When a Boolean input widget check box changes state it was not comparing the new state correctly against its current state and emitting the wrong value