### PR TITLE
Bugfix particle list not searching properly

### DIFF
--- a/leaguedirector/app.py
+++ b/leaguedirector/app.py
@@ -330,6 +330,7 @@ class ParticlesWindow(VBoxWidget):
     def __init__(self, api):
         VBoxWidget.__init__(self)
         self.api = api
+        self.api.connected.connect(self.connect)
         self.api.particles.updated.connect(self.update)
         self.items = {}
         self.search = QLineEdit()
@@ -367,7 +368,11 @@ class ParticlesWindow(VBoxWidget):
             self.items[particle].setCheckState(Qt.Checked if enabled else Qt.Unchecked)
         for particle in list(self.items):
             if not self.api.particles.hasParticle(particle):
-                self.list.removeItemWidget(self.items.pop(particle))
+                item = self.items.pop(particle)
+                self.list.takeItem(self.list.row(item))
+
+    def connect(self):
+        self.search.clear()
 
 
 class RecordingWindow(VBoxWidget):


### PR DESCRIPTION
Bugfix how the particle list updates its list item so that it correctly removes an entry from a list, and in addition clear its search box input when we connect to a replay