### PR TITLE
Bugfix for camera axis locking

### DIFF
--- a/leaguedirector/api.py
+++ b/leaguedirector/api.py
@@ -124,6 +124,9 @@ class Recording(Resource):
 class Render(Resource):
     url = '/replay/render'
     fields = {
+        'cameraLockX': False,
+        'cameraLockY': False,
+        'cameraLockZ': False,
         'cameraMode' : '',
         'cameraPosition' : {'x': 0, 'y': 0, 'z': 0},
         'cameraRotation' : {'x': 0, 'y': 0, 'z': 0},
@@ -186,36 +189,36 @@ class Render(Resource):
 
     def __init__(self):
         Resource.__init__(self)
-        self.cameraLockX = None
-        self.cameraLockY = None
-        self.cameraLockZ = None
-        self.cameraLockLast = None
+        self.cameraMoveBackX = None
+        self.cameraMoveBackY = None
+        self.cameraMoveBackZ = None
+        self.cameraMoveBackLast = None
         self.timer = QTimer()
-        self.timer.timeout.connect(self.updateCameraLock)
+        self.timer.timeout.connect(self.updateCameraMoveBack)
         self.timer.start(600)
 
-    def updateCameraLock(self, *args):
+    def updateCameraMoveBack(self, *args):
         # Wait until the camera stops moving before snapping it
-        if self.cameraLockLast != self.cameraPosition:
-            self.cameraLockLast = self.cameraPosition
+        if self.cameraMoveBackLast != self.cameraPosition:
+            self.cameraMoveBackLast = self.cameraPosition
         else:
             copy = dict(self.cameraPosition)
-            if self.cameraLockX is not None:
-                copy['x'] = self.cameraLockX
-            if self.cameraLockY is not None:
-                copy['y'] = self.cameraLockY
-            if self.cameraLockZ is not None:
-                copy['z'] = self.cameraLockZ
+            if self.cameraMoveBackX is not None:
+                copy['x'] = self.cameraMoveBackX
+            if self.cameraMoveBackY is not None:
+                copy['y'] = self.cameraMoveBackY
+            if self.cameraMoveBackZ is not None:
+                copy['z'] = self.cameraMoveBackZ
             self.cameraPosition = copy
 
-    def toggleCameraLockX(self):
-        self.cameraLockX = self.cameraPosition['x'] if self.cameraLockX is None else None
+    def toggleCameraMoveBackX(self):
+        self.cameraMoveBackX = self.cameraPosition['x'] if self.cameraMoveBackX is None else None
 
-    def toggleCameraLockY(self):
-        self.cameraLockY = self.cameraPosition['y'] if self.cameraLockY is None else None
+    def toggleCameraMoveBackY(self):
+        self.cameraMoveBackY = self.cameraPosition['y'] if self.cameraMoveBackY is None else None
 
-    def toggleCameraLockZ(self):
-        self.cameraLockZ = self.cameraPosition['z'] if self.cameraLockZ is None else None
+    def toggleCameraMoveBackZ(self):
+        self.cameraMoveBackZ = self.cameraPosition['z'] if self.cameraMoveBackZ is None else None
 
     def moveCamera(self, x=0, y=0, z=0):
         copy = dict(self.cameraPosition)

--- a/leaguedirector/app.py
+++ b/leaguedirector/app.py
@@ -155,6 +155,9 @@ class RenderWindow(QScrollArea):
         self.cameraLockX = BooleanInput('X')
         self.cameraLockY = BooleanInput('Y')
         self.cameraLockZ = BooleanInput('Z')
+        self.cameraMoveBackX = BooleanInput('X')
+        self.cameraMoveBackY = BooleanInput('Y')
+        self.cameraMoveBackZ = BooleanInput('Z')
         self.cameraPosition = VectorInput()
         self.cameraPosition.setSingleStep(10)
         self.cameraRotation = VectorInput([0, -90, -90], [360, 90, 90])
@@ -203,10 +206,12 @@ class RenderWindow(QScrollArea):
         self.depthOfFieldMid.setRelativeStep(0.05)
         self.depthOfFieldFar = FloatInput(0, 100000)
         self.depthOfFieldFar.setRelativeStep(0.05)
-
-        self.cameraLockX.valueChanged.connect(self.api.render.toggleCameraLockX)
-        self.cameraLockY.valueChanged.connect(self.api.render.toggleCameraLockY)
-        self.cameraLockZ.valueChanged.connect(self.api.render.toggleCameraLockZ)
+        self.cameraLockX.valueChanged.connect(functools.partial(self.api.render.set, 'cameraLockX'))
+        self.cameraLockY.valueChanged.connect(functools.partial(self.api.render.set, 'cameraLockY'))
+        self.cameraLockZ.valueChanged.connect(functools.partial(self.api.render.set, 'cameraLockZ'))
+        self.cameraMoveBackX.valueChanged.connect(self.api.render.toggleCameraMoveBackX)
+        self.cameraMoveBackY.valueChanged.connect(self.api.render.toggleCameraMoveBackY)
+        self.cameraMoveBackZ.valueChanged.connect(self.api.render.toggleCameraMoveBackZ)
         self.cameraPosition.valueChanged.connect(functools.partial(self.api.render.set, 'cameraPosition'))
         self.cameraRotation.valueChanged.connect(functools.partial(self.api.render.set, 'cameraRotation'))
         self.cameraAttached.valueChanged.connect(functools.partial(self.api.render.set, 'cameraAttached'))
@@ -243,6 +248,8 @@ class RenderWindow(QScrollArea):
         layout = QFormLayout()
         layout.addRow('Camera Mode', self.cameraMode)
         layout.addRow('Camera Lock', HBoxWidget(self.cameraLockX, self.cameraLockY, self.cameraLockZ))
+        layout.addRow('Camera Move Back To', HBoxWidget(self.cameraMoveBackX, self.cameraMoveBackY, self.cameraMoveBackZ))
+        layout.addRow('Camera Position', self.cameraPosition)
         layout.addRow('Camera Position', self.cameraPosition)
         layout.addRow('Camera Rotation', self.cameraRotation)
         layout.addRow('Camera Attached', self.cameraAttached)
@@ -285,12 +292,15 @@ class RenderWindow(QScrollArea):
         self.setWindowTitle('Rendering')
 
     def update(self):
-        self.cameraLockX.update(self.api.render.cameraLockX is not None)
-        self.cameraLockY.update(self.api.render.cameraLockY is not None)
-        self.cameraLockZ.update(self.api.render.cameraLockZ is not None)
-        self.cameraLockX.setCheckboxText('{0:.2f}'.format(self.api.render.cameraLockX) if self.api.render.cameraLockX else 'X')
-        self.cameraLockY.setCheckboxText('{0:.2f}'.format(self.api.render.cameraLockY) if self.api.render.cameraLockY else 'Y')
-        self.cameraLockZ.setCheckboxText('{0:.2f}'.format(self.api.render.cameraLockZ) if self.api.render.cameraLockZ else 'Z')
+        self.cameraLockX.update(self.api.render.cameraLockX)
+        self.cameraLockY.update(self.api.render.cameraLockY)
+        self.cameraLockZ.update(self.api.render.cameraLockZ)
+        self.cameraMoveBackX.update(self.api.render.cameraMoveBackX is not None)
+        self.cameraMoveBackY.update(self.api.render.cameraMoveBackY is not None)
+        self.cameraMoveBackZ.update(self.api.render.cameraMoveBackZ is not None)
+        self.cameraMoveBackX.setCheckboxText('{0:.2f}'.format(self.api.render.cameraMoveBackX) if self.api.render.cameraMoveBackX else 'X')
+        self.cameraMoveBackY.setCheckboxText('{0:.2f}'.format(self.api.render.cameraMoveBackY) if self.api.render.cameraMoveBackY else 'Y')
+        self.cameraMoveBackZ.setCheckboxText('{0:.2f}'.format(self.api.render.cameraMoveBackZ) if self.api.render.cameraMoveBackZ else 'Z')
         self.cameraMode.setText(self.api.render.cameraMode)
         self.cameraPosition.update(self.api.render.cameraPosition)
         self.cameraRotation.update(self.api.render.cameraRotation)
@@ -770,12 +780,18 @@ class Api(QObject):
             self.render.rotateCamera(z=1)
         elif name == 'camera_roll_right':
             self.render.rotateCamera(z=-1)
+        elif name == 'camera_move_back_x':
+            self.render.toggleCameraMoveBackX()
+        elif name == 'camera_move_back_y':
+            self.render.toggleCameraMoveBackY()
+        elif name == 'camera_move_back_z':
+            self.render.toggleCameraMoveBackZ()
         elif name == 'camera_lock_x':
-            self.render.toggleCameraLockX()
+            self.render.cameraLockX = not self.render.cameraLockX
         elif name == 'camera_lock_y':
-            self.render.toggleCameraLockY()
+            self.render.cameraLockY = not self.render.cameraLockY
         elif name == 'camera_lock_z':
-            self.render.toggleCameraLockZ()
+            self.render.cameraLockZ = not self.render.cameraLockZ
         elif name == 'camera_attach':
             self.render.cameraAttached = not self.render.cameraAttached
         elif name == 'camera_fov_up':
@@ -989,6 +1005,9 @@ class LeagueDirector(object):
             ('camera_lock_x',               'Camera Lock X Axis',               ''),
             ('camera_lock_y',               'Camera Lock Y Axis',               ''),
             ('camera_lock_z',               'Camera Lock Z Axis',               ''),
+            ('camera_move_back_x',          'Camera Lock X Axis',               ''),
+            ('camera_move_back_y',          'Camera Lock Y Axis',               ''),
+            ('camera_move_back_z',          'Camera Lock Z Axis',               ''),
             ('camera_attach',               'Camera Attach',                    ''),
             ('camera_fov_up',               'Camera Increase Field of View',    ''),
             ('camera_fov_down',             'Camera Decrease Field of View',    ''),


### PR DESCRIPTION
Extended Render class to include additional fields for camera locking on the x, y and z axis. In addition, keeping previous camera locking controls and instead renaming them to their functionality of camera move back